### PR TITLE
R port of Python SpringRank

### DIFF
--- a/r/springrank.R
+++ b/r/springrank.R
@@ -1,0 +1,140 @@
+library(igraph)
+library(Matrix)
+library(Rlinsolve)
+
+spring_rank <- function(A, alpha = 0, l0 = 1.0, l1 = 1.0, shift = TRUE) {
+  #' Core function for calculating SpringRank.
+  #' Default parameters follow stanadard model.
+  #'
+  #' @param A The adjacency matrix of the graph. This should be a sparse dgCMatrix;
+  #' if it isn't it will be coerced to a dgCMatrix.
+  #' @param alpha Controls the impact regularization term.
+  #' @param l0 Regularization spring's rest length.
+  #' @param l1 Interaction springs' rest length.
+  #' @param shift (Optional, default TRUE) normalize such that the lowest-ranked
+  #'  node has a SpringRank value of zero.
+  #'
+  #' @return A vector of SpringRank scores for each node. Sort or order the
+  #' vector for ordinal rankings of each node.
+
+  if (class(A) == "matrix") {
+   # coerce dense matrix to sparse matrice so the user doesn't have to.
+   A <- as(Matrix(A, sparse = TRUE, doDiag = FALSE), "dgCMatrix")
+  } else {
+    # confirm it's the right kind of sparse matrix. might throw an error
+    # if it's one of the less common sparse matrix types.
+    A <- as(A, "dgCMatrix")
+  }
+
+  N <- dim(A)[1]
+  k_in <- colSums(A)
+  k_out <- rowSums(A)
+  One <- as(Matrix(rep(1, N)), "dgCMatrix")
+  C <- A + t(A)
+
+  D1 <- as(Matrix(0, ncol = N, nrow = N), "dgCMatrix")
+  D2 <- as(Matrix(0, ncol = N, nrow = N), "dgCMatrix")
+
+  for (i in 1:N) {
+    D1[i, i] <- k_out[i] + k_in[i]
+    D2[i, i] <- l1 * (k_out[i] - k_in[i])
+  }
+
+  if (alpha != 0) {
+    print("assuming invertible matrix")
+
+    B = One * l0 + D2 %*% One
+    A_ = alpha * diag(nrow = N, ncol = N) + D1 - C
+
+    solvable = class(try(as.matrix(solve(A_, B)), silent = T)) == "matrix"
+    if (solvable)
+    {
+      print("using solve")
+      rank <- solve(A_, B)
+    } else {
+      print("using bigcstab")
+      rank <- Rlinsolve::lsolve.bicgstab(A_, B, verbose = F)
+      rank <- rank$x
+    }
+
+    if (shift) {
+      rank <- rank - min(rank)
+    }
+
+  } else {
+    print("fixing a rank degree of freedom")
+    C <- C +
+      matrix(rep(A[N,] , times = N),
+             ncol = N,
+             nrow = N,
+             byrow = T) +
+      matrix(rep(A[, N], times = N),
+             ncol = N,
+             nrow = N,
+             byrow = T)
+    D3 <- as(Matrix(0, ncol = N, nrow = N), "dgCMatrix")
+    for (i in 1:N) {
+      D3[i, i] <- l1 * (k_out[N] - k_in[N])
+    }
+
+    B <- D2 %*% One + D3 %*% One
+    A_ <- D1 - C
+
+    rank <- solve(A_, B)
+
+    if (shift) {
+      rank <- rank - min(rank)
+    }
+  }
+
+  # matrix to vector, so we can use names()
+  rank <- rank[,1]
+  names(rank) <- colnames(A)
+  return(rank)
+}
+
+
+spring_rank_network <- function(N, beta, alpha, K, l0 = 0.5, l1 = 1.0) {
+  #' Generative model for SpringRank. Builds a weighted graph with self-loops.
+  #' The model first generates node scores using a normal distribution, then
+  #' generates edges (and edge weights) from a Poisson distribution with mean
+  #' equal to the energy of the system.
+  #'
+  #' @param N The number of nodes.
+  #' @param beta Inverse temperature, a noise parameter.
+  #' @param alpha Variance of the Normal prior.
+  #' @param K The average degree of the network.
+  #' @param l0 Prior spring's rest length.
+  #' @param l1 Interaction spring's rest length.
+  #'
+  #' @return A directed graph (potentially weighted, potentially containing
+  #' self-loops)
+
+  scores <- rnorm(N, l0, 1/sqrt(alpha*beta))
+  Z <- 0
+  for (i in 1:N) {
+    for (j in 1:N) {
+      Z = Z + exp(-0.5 * beta * (scores[i] - scores[j] - l1)^2)
+    }
+  }
+  C = (K*N)/Z
+  A = Matrix(0, N, N)
+
+  for (i in 1:N) {
+    for (j in 1:N) {
+
+      H_ij = .5 * (scores[i] - scores[j] - l1)^2
+      lambda_ij = C * exp(-1 * beta * H_ij)
+
+      A_ij = rpois(1, lambda_ij)
+
+      if (A_ij > 0) {
+        A[i, j] = A_ij
+      }
+    }
+  }
+
+  return(graph_from_adjacency_matrix(A, mode = "directed", weighted = TRUE))
+}
+
+

--- a/r/test_springrank.R
+++ b/r/test_springrank.R
@@ -1,0 +1,23 @@
+# This just runs the test script, same as the Python version, but a
+# bit more barebones.
+
+library(readr)
+library(igraph)
+library(Matrix)
+
+source("springrank.R")
+
+df <- read_delim("../data/US_CS_adjacency.dat",
+                 delim = " ",
+                 col_names = c("i", "j", "weight"))
+
+G <- graph.data.frame(df)
+A <- as.matrix(as_adjacency_matrix(G, attr = "weight"))
+A <- Matrix(A) # sparsify A
+
+alpha <- 0.0
+l0 <- 1.0
+l1 <- 1.0
+
+r <- spring_rank(A, alpha, l0, l1)
+print(round(rev(r[order(r)]), 3))


### PR DESCRIPTION
This commit adds a fairly straightforward R port of the Python SpringRank
algorithm (refer issue #3). It's basically a line-for-line translation, with few
considerations for "proper" R style. I believe the only difference in
implementation is that scipy uses an iterative solver, whereas the R
version does not. (This should in principle be a straightforward change but
I know next to nothing about numerical methods, or on what best
practices are when calling something other than simple `solve()` in R.)

This commit also includes an R implementation of the generative model. I
haven't tested it extensively, but (i) it produces correct-looking
graph (in terms of N, average and s.d. of degree) and (ii) it's a fairly
simple model so there shouldn't have been too many places for me to
screw it up!