### PR TITLE
Remove phantom dependency

### DIFF
--- a/python/SpringRank/_core.py
+++ b/python/SpringRank/_core.py
@@ -8,7 +8,6 @@ import warnings
 import numpy as np
 import scipy.sparse
 import scipy.sparse.linalg
-import sparse
 
 
 def build_from_dense(A, alpha, l0, l1):


### PR DESCRIPTION
I don't think this module exists / is used? Creates an import error and can't find it in the code elsewhere.